### PR TITLE
fix: support new States functions

### DIFF
--- a/src/__tests__/validatePath.test.ts
+++ b/src/__tests__/validatePath.test.ts
@@ -53,6 +53,63 @@ describe("unit tests for the parser", () => {
       path: "States.Format('{}_{}',$$.Execution.Name,$['test-batch']['batch_id'])",
       valid_in: PayloadTemplatesOnly,
     },
+    // new functions from 2022-08
+    {
+      path: "States.ArrayPartition($.inputArray,4)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.ArrayContains($.inputArray, $.lookingFor)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.ArrayRange(1, 9, 2)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.ArrayGetItem($.inputArray, $.index)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.ArrayLength($.inputArray)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.ArrayUnique($.inputArray)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.Base64Encode($.input)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.Base64Decode($.base64)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.Hash($.Data, $.Algorithm)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.JsonMerge($.json1, $.json2, false)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.MathRandom($.start, $.end)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.MathAdd($.value1, $.step)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.StringSplit($.inputString, $.splitter)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.UUID()",
+      valid_in: PayloadTemplatesOnly,
+    },
 
     // assorted paths
     {

--- a/src/aslPaths.pegjs
+++ b/src/aslPaths.pegjs
@@ -44,10 +44,31 @@ subscriptableBareword
    / WILDCARD_SUBSCRIPT
 
 intrinsic_function
-	= func:"States.Format" args:function_args {return {func, args}}
+    = func:"States.Array" args:function_args {return {func, args}}
+    / func:"States.ArrayPartition" args:function_args {return {func, args}}
+    / func:"States.ArrayContains" args:function_args {return {func, args}}
+    / func:"States.ArrayRange" args:function_args {return {func, args}}
+    / func:"States.ArrayGetItem" args:function_args {return {func, args}}
+    / func:"States.ArrayLength" args:single_arg {return {func, args}}
+    / func:"States.ArrayUnique" args:single_arg {return {func, args}}
+    / func:"States.Base64Encode" args:single_arg {return {func, args}}
+    / func:"States.Base64Decode" args:single_arg {return {func, args}}
+    / func:"States.Hash" args:function_args {return {func, args}}
+    / func:"States.JsonMerge" args:function_args {return {func, args}}
     / func:"States.StringToJson" args:single_arg {return {func, args}}
     / func:"States.JsonToString" args:single_arg {return {func, args}}
-    / func:"States.Array" args:function_args {return {func, args}}
+    / func:"States.MathRandom" args:function_args {return {func, args}}
+    / func:"States.MathAdd" args:function_args {return {func, args}}
+    / func:"States.StringSplit" args:function_args {return {func, args}}
+    / func:"States.UUID" args:no_args {return {func, args}}
+	/ func:"States.Format" args:function_args {return {func, args}}
+
+no_args
+   = PAREN_LEFT _ PAREN_RIGHT
+   {return {
+   	head: null,
+    tail: [] }
+   }
 
 single_arg
    = PAREN_LEFT _ head:jsonpath__ _ PAREN_RIGHT
@@ -130,4 +151,3 @@ escaped = "\\" c:allchars { return c; }
 allchars = $[^\\n]
 
 _ "whitespace" = [ \t\n]*
-


### PR DESCRIPTION
AWS recently added 14 new intrinsic functions

this PR adds their names/args to the parser

I'll revisit later to support any future "States." function since that's their namespace prefix. Doing that would mean not having to update each time at the cost of not being able to validate the args.