### PR TITLE
improve validation of MathAdd

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asl-path-validator",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Validates the path expressions for the Amazon States Language",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/__tests__/validatePath.test.ts
+++ b/src/__tests__/validatePath.test.ts
@@ -133,6 +133,38 @@ describe("unit tests for the parser", () => {
       valid_in: PayloadTemplatesOnly,
     },
     {
+      path: "States.MathAdd($.value1, -1)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.MathAdd($.value1, 1)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.MathAdd(1, -1)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.MathAdd(-1, -1)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.MathAdd(1, $.step)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.MathAdd(-1, $.step)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
+      path: "States.MathAdd('-1', 'abc')",
+      valid_in: None,
+    },
+    {
+      path: "States.MathAdd(States.ArrayLength($$.Execution.Input.machines),-1)",
+      valid_in: PayloadTemplatesOnly,
+    },
+    {
       path: "States.StringSplit($.inputString, $.splitter)",
       valid_in: PayloadTemplatesOnly,
     },

--- a/src/aslPaths.pegjs
+++ b/src/aslPaths.pegjs
@@ -63,7 +63,10 @@ intrinsic_function
     / func:"States.StringToJson" args:single_arg {return {func, args}}
     / func:"States.JsonToString" args:single_arg {return {func, args}}
     / func:"States.MathRandom" args:function_args {return {func, args}}
-    / func:"States.MathAdd" args:function_args {return {func, args}}
+    / func:"States.MathAdd" PAREN_LEFT _ arg1:jsonpath_ _ COMMA _ arg2:jsonpath_ _ PAREN_RIGHT {return {func, arg1, arg2}}
+    / func:"States.MathAdd" PAREN_LEFT _ arg1:jsonpath_ _ COMMA _ arg2:(MINUS? NUMBER) _ PAREN_RIGHT {return {func, arg1, arg2}}
+    / func:"States.MathAdd" PAREN_LEFT _ arg1:(MINUS? NUMBER) _ COMMA _ arg2:jsonpath_ _ PAREN_RIGHT {return {func, arg1, arg2}}
+    / func:"States.MathAdd" PAREN_LEFT _ arg1:(MINUS? NUMBER) _ COMMA _ arg2:(MINUS? NUMBER) _ PAREN_RIGHT {return {func, arg1, arg2}}
     / func:"States.StringSplit" args:function_args {return {func, args}}
     / func:"States.UUID" args:no_args {return {func, args}}
 	/ func:"States.Format" args:function_args {return {func, args}}

--- a/src/aslPaths.pegjs
+++ b/src/aslPaths.pegjs
@@ -122,7 +122,7 @@ comparison_op
 
 value
    = STRING
-   / NUMBER
+   / minus:MINUS? nbr:NUMBER { return (minus === '-' ? -1 : 1) * parseFloat(nbr)}
    / TRUE
    / FALSE
    / NULL


### PR DESCRIPTION
The grammar wasn't allowing negative numbers for function args. Small change there to fix and then rewrote the MathAdd grammar to accept only paths or numbers in order to reject strings and other arg types